### PR TITLE
Add FFMPEG to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You should basically always do this before you start installing stuff on Linux.
 
 ### Install Packages
 
-`sudo apt install python3-pip python3-dev python3-setuptools python3-venv git libyaml-dev build-essential`
+`sudo apt install python3-pip python3-dev python3-setuptools python3-venv git libyaml-dev build-essential ffmpeg`
 
 ### Setup Octoprint Folder
 


### PR DESCRIPTION
FFMPEG is required for the setup of OctoPrint. It is not installed by default on quadra systems.